### PR TITLE
fix(*): use provider state when passed undefined theme prop

### DIFF
--- a/src/create-theme-test.tsx
+++ b/src/create-theme-test.tsx
@@ -23,6 +23,20 @@ test('should pass theme prop from Context to wrapped component', () => {
     expect(FakeComponent).toHaveBeenCalledWith({ theme: 'yellow' }, expect.anything());
 });
 
+test('should use theme provider theme when passed theme prop with undefined value', () => {
+    const { ThemeProvider, withTheme } = createTheme('theme');
+    const FakeComponent = jest.fn().mockReturnValue(null);
+    const TestComponent = withTheme(FakeComponent);
+
+    mount(
+        <ThemeProvider value='yellow'>
+            <TestComponent theme={undefined} />
+        </ThemeProvider>
+    );
+
+    expect(FakeComponent).toHaveBeenCalledWith({ theme: 'yellow' }, expect.anything());
+});
+
 test('should allow to override theme when it was passed directly as props to component', () => {
     const { ThemeProvider, withTheme } = createTheme('theme');
     const FakeComponent = jest.fn().mockReturnValue(null);

--- a/src/create-theme.tsx
+++ b/src/create-theme.tsx
@@ -6,10 +6,10 @@ export function createTheme<T>(defaultTheme: T) {
     function withTheme<P extends { theme?: T }>(
         Component: React.ComponentType<P>
     ): React.ComponentType<P & React.RefAttributes<any>> {
-        const ForwardRef: React.RefForwardingComponent<React.Component<P>, P> = (props, ref) => {
+        const ForwardRef: React.RefForwardingComponent<React.Component<P>, P> = ({ theme, ...props }, ref) => {
             return (
                 <ThemeContext.Consumer>
-                    { state => <Component theme={ state || defaultTheme } { ...props } ref={ ref }  /> }
+                    { state => <Component theme={ theme || state || defaultTheme } { ...props as any } ref={ ref }  /> }
                 </ThemeContext.Consumer>
             );
         };


### PR DESCRIPTION
В коде user в компоненл link передается 

```
<Link theme={ this.props.theme } ...
```

В этом кейсе если theme пришел неправильный то в theme ниче не проставится

Смотрим что было в старом добром cndecorator
https://github.com/alfa-laboratory/cn-decorator/blob/master/src/cn.js#L171

Интересно что cn не просовывал то что в контексте как проп, а только использовал в рендере класса