### PR TITLE
fix(*): adds fix for package.json version

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -7,6 +7,10 @@ module.exports = {
             '@semantic-release/npm',
             { pkgRoot: './.publish' }
         ],
+        [
+            '@semantic-release/npm',
+            { npmPublish: false }
+        ],
         '@semantic-release/git',
         '@semantic-release/github',
     ],


### PR DESCRIPTION
Правит обновление версии.
Проблема была в `release.config.js`. Обновлялся только package который отправляется в npm, чтобы это пофиксить надо вызывать semantic-release/npm два раза
```
        [
            '@semantic-release/npm', - этот с помощью pkgRoot найдет package для npm, обновит версии и отправит.
            {
                pkgRoot: './.publish'
            }
        ],
        [
            '@semantic-release/npm',- у этого по дефолту pkgRoot= '.' , он обновит его, но npmPublish, не даст его отправить.
            {
                npmPublish: false
            }
        ],
```

В такой связке все работает правильно. 
